### PR TITLE
add open-liberty starter kit

### DIFF
--- a/public/data/links.json
+++ b/public/data/links.json
@@ -58,6 +58,7 @@
   {"title":"Typescript Microservice", "subtitle":"Node.js TypeScript Microservice offering OpenAPI endpoints","language":"TypeScript","href":"https://github.com/IBM/template-node-typescript","color":"light"},
   {"title":"Spring Boot Microservice", "subtitle":"Spring Boot Java Microservice","language":"Java","href":"https://github.com/IBM/template-java-spring","color":"light"},
   {"title":"Quarkus Microservice", "subtitle":"Quarkus Java Microservice","language":"Java","href":"https://github.com/IBM/template-quarkus","color":"light"},
+  {"title":"Liberty Microservice", "subtitle":"Open Liberty Java Microservice","language":"Java","href":"https://github.com/IBM/template-liberty","color":"light"},
   {"title":"Go Gin Microservice", "subtitle":"Go Gin Microservice/Edge","language":"Go","href":"https://github.com/IBM/template-go-gin","color":"light"}
   ],
   "argocd" : [


### PR DESCRIPTION
Signed-off-by: Larry Steck <lsteck@us.ibm.com>

Add Open-Liberty starter kit to developer dashboard.

part of cloud-native-toolkit/planning#676

